### PR TITLE
Built new wheels v1.1.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest,macos-latest]
+        include:
+          - os: ubuntu-22.04
+            cibw_archs: "native"
+          - os: ubuntu-22.04
+            cibw_archs: "aarch64"
+          - os: windows-latest
+            cibw_archs: "native ARM64"
+          - os: macos-latest
+            cibw_archs: "native arm64"
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +32,7 @@ jobs:
 
       - name: Build wheels
         env: 
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
           CI_BEFORE_ALL_LINUX: sudo apt-get install gfortran
           CIBW_BEFORE_ALL_MACOS: brew install gcc && brew reinstall gfortran
           CIBW_BEFORE_BUILD: "pip install numpy"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.7.4
+          python -m pip install cibuildwheel==2.12.1
 
       - name: Build wheels
         env: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-18.04, windows-latest,macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: '3.9'
@@ -31,6 +31,6 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.9'
@@ -31,6 +31,6 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@3
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
It appear we already bumped to version v1.1.4 but never uploaded these. Since many of the wheels were outdated and not built for all platforms, I reran all the actions and we now have support for Python 3.6 to 3.11 (even though Python 3.6 is deprecated). 