### PR TITLE
Increase number of lineOutputs and add datafile for a-Ch3OH

### DIFF
--- a/src/radex_src/new.pyf
+++ b/src/radex_src/new.pyf
@@ -18,7 +18,7 @@ subroutine from_params(molfilein,tkinin,tbgin,cdmolin,densityin,linewidthin,fmin
     integer intent(out) :: nlines
     character(len=6) dimension(3000),intent(out) :: qup
     character(len=6) dimension(3000),intent(out) :: qlow
-    double precision dimension(10,500),intent(out) :: lineoutputs
+    double precision dimension(10,5000),intent(out) :: lineoutputs
 end subroutine from_params
 subroutine from_dict(inputdictionary,success_flag,nlines,qup,qlow,lineoutputs) ! in wrap.f90
     use io
@@ -29,7 +29,7 @@ subroutine from_dict(inputdictionary,success_flag,nlines,qup,qlow,lineoutputs) !
     integer intent(out) :: nlines
     character(len=6) dimension(3000),intent(out) :: qup
     character(len=6) dimension(3000),intent(out) :: qlow
-    double precision dimension(10,500),intent(out) :: lineoutputs
+    double precision dimension(10,5000),intent(out) :: lineoutputs
 end subroutine from_dict
 
 ! This file was auto-generated with f2py (version:2).

--- a/src/radex_src/radexwrap.pyf
+++ b/src/radex_src/radexwrap.pyf
@@ -12,7 +12,7 @@ python module radexwrap ! in
             integer intent(out) :: success_flag
             character(len=6) dimension(3000),intent(out) :: qup
             character(len=6) dimension(3000),intent(out) :: qlow
-            double precision dimension(10,500),intent(out) :: lineoutputs
+            double precision dimension(10,5000),intent(out) :: lineoutputs
         end subroutine from_dict
         subroutine from_params(molfilein,tkinin,tbgin,cdmolin,densityin,linewidthin,fminin,fmaxin,geometryin,success_flag,nlines,qup,qlow,lineoutputs) ! in wrap.f90
             use io
@@ -31,7 +31,7 @@ python module radexwrap ! in
             integer intent(out) :: nlines
             character(len=6) dimension(3000),intent(out) :: qup
             character(len=6) dimension(3000),intent(out) :: qlow
-            double precision dimension(10,500),intent(out) :: lineoutputs
+            double precision dimension(10,5000),intent(out) :: lineoutputs
         end subroutine from_params
     end interface 
 end python module radexwrap

--- a/src/radex_src/wrap.f90
+++ b/src/radex_src/wrap.f90
@@ -22,7 +22,7 @@ IMPLICIT NONE
     !Main program: controls program flow and drives subroutines
     CHARACTER(*) :: molfileIn
     INTEGER :: niter,nlines,success_flag,iline,geometryIn   ! iteration counters
-    DOUBLE PRECISION :: tkinIn,tbgIn,cdmolIn,densityIn(7),lineOutputs(10,500)
+    DOUBLE PRECISION :: tkinIn,tbgIn,cdmolIn,densityIn(7),lineOutputs(10,5000)
     DOUBLE PRECISION :: linewidthIn,fminIn,fmaxIn
     CHARACTER(6) :: Qup(3000),Qlow(3000)
     LOGICAL :: conv    ! are we converged?
@@ -98,7 +98,7 @@ IMPLICIT NONE
     !Main program: controls program flow and drives subroutines
     CHARACTER(*) :: inputDictionary
     INTEGER :: niter,nlines,success_flag,iline   ! iteration counters
-    DOUBLE PRECISION :: lineOutputs(10,500)
+    DOUBLE PRECISION :: lineOutputs(10,5000)
     CHARACTER(6) :: Qup(3000),Qlow(3000)
     LOGICAL :: conv    ! are we converged?
     !f2py intent(in) inputDictionary


### PR DESCRIPTION
500 lineoutputs is not enough to run spectral radex on methanol: increasing it to 5000 works. Additionally, the datafile for methanol does not come with the current version of the code, and the user has to download it separately, which is non-ideal.