### PR TITLE
upload radex origin revision

### DIFF
--- a/src/radex_src/commondata.f90
+++ b/src/radex_src/commondata.f90
@@ -3,7 +3,7 @@ USE types
 IMPLICIT NONE
 
     !file for input and output
-    character(200) :: outfile,molfile,specref
+    character(200) :: outfile,molfile,molfileold,specref
     character(*), PARAMETER :: radat='./data/'
     character(*), PARAMETER :: version = '30nov2011'
     character(*), PARAMETER :: logfile = './radex.log'
@@ -115,7 +115,11 @@ IMPLICIT NONE
     ! ctot:  total collision rate 
     ! xpop:  level populations
 
-
+    INTEGER :: id(maxpart)      ! to identify collision partners
+    INTEGER :: lcu(maxpart,maxcoll),lcl(maxpart,maxcoll)
+    REAL(dp) :: coll(maxpart,maxcoll,maxtemp)
+    REAL(dp) :: temp(maxpart,maxtemp) ! collision temperatures
+    character*120 collref ! text about source of collisional data
 
     !For development / maintenance purposes:
     LOGICAL, PARAMETER :: debug =.False.

--- a/src/radex_src/wrap.f90
+++ b/src/radex_src/wrap.f90
@@ -44,7 +44,10 @@ IMPLICIT NONE
 
     IF (success_flag .ne. 1) RETURN
     IF (DEBUG) write(*,*) 'calling readdata'
-    CALL ReadData(success_flag)
+    IF (molfile .ne. molfileold) THEN
+      CALL ReadData(success_flag)
+    END IF
+    CALL InterpColli(success_flag)
     IF (success_flag .ne. 1) RETURN
 
     !     Calculate background radiation field
@@ -88,6 +91,7 @@ IMPLICIT NONE
         niter=niter+1
         END IF
     END DO
+    molfileold=molfile
 END SUBROUTINE from_params
     
 SUBROUTINE from_dict(inputDictionary,success_flag,nlines,Qup,Qlow,lineOutputs)
@@ -111,7 +115,10 @@ IMPLICIT NONE
     !     Read data file
     IF (success_flag .ne. 1) RETURN
     IF (DEBUG) write(*,*) 'calling readdata'
-    CALL ReadData(success_flag)
+    IF (molfile .ne. molfileold) THEN
+      CALL ReadData(success_flag)
+    END IF
+    CALL InterpColli(success_flag)
     IF (success_flag .ne. 1) RETURN
 
     !     Calculate background radiation field
@@ -155,4 +162,5 @@ IMPLICIT NONE
         niter=niter+1
       END IF
     END DO
+    molfileold=molfile
 END SUBROUTINE from_dict


### PR DESCRIPTION
I have revise some bugs and updates to the original radex code.

1. About the unconverge solutions: I change the step length during solving the statistic equilibrium equations. Origin is 0.3, now called lr. This avoid almost all of the unconverge solution.
2. When calculating escape probability, sometimes the optical depth becomes negative temporarily. The previous treatment is exp(-tau), this value can be a very large value which calls bugs. I apply a linear interpolation to the negative value. 
3. (optional) When running parameter grids, the scripts read the molecular file for each time. Now when the file is the same as the molefileold, the program will skip loading the file. The program will 5.5 time faster than before when running the grid.